### PR TITLE
Updated output_parser.py to accommodate RF4.0

### DIFF
--- a/test_archiver/output_parser.py
+++ b/test_archiver/output_parser.py
@@ -86,9 +86,11 @@ class RobotFrameworkOutputParser(XmlOutputParser):
             pass
         elif name == 'item':  # metadata item
             self.archiver.begin_metadata(attrs.getValue('name'))
+        elif name == 'meta':  # metadata item # RF4.0
+            self.archiver.begin_metadata(attrs.getValue('name'))
         elif name == 'doc':
             pass
-        elif name in ('arguments', 'tags', 'metadata'):
+        elif name in ('arguments', 'tags', 'metadata', 'for', 'iter', 'value'):
             pass
         else:
             print("WARNING: begin unknown item '{}'".format(name))
@@ -124,9 +126,11 @@ class RobotFrameworkOutputParser(XmlOutputParser):
                 self.archiver.update_tags(self.content())
         elif name == 'item':  # metadata item
             self.archiver.end_metadata(self.content())
+        elif name == 'meta':  # metadata item # RF4.0
+            self.archiver.end_metadata(self.content())
         elif name == 'doc':
             pass
-        elif name in ('arguments', 'tags', 'metadata'):
+        elif name in ('arguments', 'tags', 'metadata', 'for', 'iter', 'value'):
             pass
         else:
             print("WARNING: ending unknown item '{}'".format(name))


### PR DESCRIPTION
As per latest RF4.0 output.xml format has been changed and metadata tag has been modified. Code change is to accommodate the metadata changes. Below are additional details for reference.
https://github.com/robotframework/robotframework/blob/master/doc/releasenotes/rf-4.0rc1.rst#id101
https://github.com/robotframework/robotframework/issues/3853
In order to accommodate the backward compatibility I have added an additional if condition to check for meta.. so metadata information will get inserted even in RF3.2.2 or RF4.0 is used.
Please review